### PR TITLE
Fix the syncronize button.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -5,7 +5,7 @@
     android:versionName="1.0" >
 
     <uses-sdk
-        android:minSdkVersion="8"
+        android:minSdkVersion="10"
         android:targetSdkVersion="16" />
 
     <!-- Indicam que a aplicação tem acesso ao envio e leitura de SMS -->


### PR DESCRIPTION
1) If you don't has a SDCard, when you click this button, the app will break.

2) If you has music files in "Music" folder and another one, the app will break too.
Because the processFiles method get a file list as parameter (actually search only Music
folder), but it's redo the search in SDCard full.

Now, the processFiles just process the file list parameter.

This patch fix these two cases. It uses the MetadataRetriever class, so
the minSdkVersion is 10, for now.
